### PR TITLE
feat: define L0 PDF parser interfaces

### DIFF
--- a/internal/pdf/interfaces.go
+++ b/internal/pdf/interfaces.go
@@ -1,0 +1,22 @@
+package pdf
+
+import "io"
+
+// Reader provides access to PDF document content.
+// Implementations must be safe to call Pages() multiple times.
+type Reader interface {
+	// Open initializes the reader from a byte stream.
+	Open(r io.ReadSeeker) error
+
+	// Metadata returns document-level metadata.
+	Metadata() (Metadata, error)
+
+	// PageCount returns the total number of pages.
+	PageCount() int
+
+	// Page extracts content from a single page (1-indexed).
+	Page(number int) (Page, error)
+
+	// Close releases any resources held by the reader.
+	Close() error
+}


### PR DESCRIPTION
## Issue
Closes #3

## Summary
- Add `Reader` interface in `internal/pdf/interfaces.go` defining the L0 PDF parser contract
- Interface provides 5 methods: `Open`, `Metadata`, `PageCount`, `Page`, and `Close`
- Only imports stdlib (`io`), respecting layer boundary rules (L0 cannot import other internal packages)

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Build passes (`go build ./internal/pdf/...`)
- [x] All tests pass (`make test`)

## Notes
- Types (`Rect`, `TextElement`, `PageSize`, `Page`, `Metadata`) were already defined in `types.go` from PR #1
- The `Reader` interface uses `io.ReadSeeker` for `Open` to support re-reading
- Implementations must be safe to call `Pages()` multiple times as documented