### PR TITLE
feat: define L1 layout engine interfaces

### DIFF
--- a/internal/layout/interfaces.go
+++ b/internal/layout/interfaces.go
@@ -1,0 +1,9 @@
+package layout
+
+import "github.com/lugassawan/idxlens/internal/pdf"
+
+// Analyzer processes raw PDF pages into structured layouts.
+type Analyzer interface {
+	// Analyze takes a PDF page and returns the assembled layout.
+	Analyze(page pdf.Page) (LayoutPage, error)
+}


### PR DESCRIPTION
## Issue
Closes #5

## Summary
- Add `Analyzer` interface to `internal/layout/interfaces.go` — defines the L1 boundary contract for processing raw PDF pages into structured layouts
- Single method `Analyze(page pdf.Page) (LayoutPage, error)` takes L0 types as input and returns L1 types

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Package builds (`go build ./internal/layout/...`)
- [x] All tests pass (`make test`)
- [x] No upward dependency violations — L1 imports only L0 (`internal/pdf`)

## Notes
- Types (`TextLine`, `Region`, `LayoutPage`) were defined in a previous PR in `types.go` — this PR adds only the interface