### PR TITLE
chore: add .claude/worktrees to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ coverage/
 # Worktrees
 .worktrees/
 .claude/.worktrees
+.claude/worktrees/
 
 # Local scratch
 /tmp/


### PR DESCRIPTION
## Summary

- Add `.claude/worktrees/` to `.gitignore` to prevent Claude Code worktree directories from being tracked

## Test plan

- [x] Verify `.claude/worktrees/` is listed in `.gitignore`
- [x] CI passes