### PR TITLE
feat: define L2 table detector interfaces

### DIFF
--- a/internal/table/interfaces.go
+++ b/internal/table/interfaces.go
@@ -1,0 +1,9 @@
+package table
+
+import "github.com/lugassawan/idxlens/internal/layout"
+
+// Detector identifies and extracts tables from layout-analyzed pages.
+type Detector interface {
+	// Detect finds all tables in a layout page.
+	Detect(page layout.LayoutPage) ([]Table, error)
+}

--- a/internal/table/types.go
+++ b/internal/table/types.go
@@ -1,0 +1,37 @@
+package table
+
+import "github.com/lugassawan/idxlens/internal/pdf"
+
+// Cell represents a single cell in a detected table.
+type Cell struct {
+	Text    string
+	Row     int
+	Col     int
+	Bounds  pdf.Rect
+	Merged  bool
+	RowSpan int
+	ColSpan int
+}
+
+// Row represents a table row.
+type Row struct {
+	Index int
+	Cells []Cell
+}
+
+// Column represents metadata about a table column.
+type Column struct {
+	Index     int
+	X1        float64 // left edge
+	X2        float64 // right edge
+	Alignment string  // "left", "right", "center"
+}
+
+// Table represents a detected table structure.
+type Table struct {
+	Rows    []Row
+	Columns []Column
+	Bounds  pdf.Rect
+	PageNum int
+	Headers []string // column header texts
+}


### PR DESCRIPTION
## Issue
Closes #13

## Summary
- Add `internal/table/types.go` with `Cell`, `Row`, `Column`, and `Table` types for representing detected table structures
- Add `internal/table/interfaces.go` with `Detector` interface defining the L2 table detection contract
- Dependencies flow strictly downward: L2 imports L1 (`layout`) and L0 (`pdf`) only

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Package compiles (`go build ./internal/table/...`)
- [x] All existing tests pass (`make test`)

## Notes
This is an interface-only change with no implementation yet. The `Detector` interface will be implemented in a follow-up issue.