### PR TITLE
feat: add ESG/GRI index extractor

### DIFF
--- a/internal/domain/esg.go
+++ b/internal/domain/esg.go
@@ -1,0 +1,208 @@
+package domain
+
+import (
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/lugassawan/idxlens/internal/table"
+)
+
+// GRI disclosure statuses.
+const (
+	StatusReported          = "reported"
+	StatusPartiallyReported = "partially reported"
+	StatusNotReported       = "not reported"
+)
+
+// griPattern matches GRI disclosure numbers in formats like "GRI 201-1",
+// "201-1", or "GRI201-1".
+var griPattern = regexp.MustCompile(`(?i)(?:GRI\s*)?(\d{3}-\d+)`)
+
+// GRIDisclosure represents a single GRI Standards disclosure entry from an
+// ESG/sustainability content index table.
+type GRIDisclosure struct {
+	Number      string `json:"number"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	PageRef     string `json:"page_ref"`
+	Status      string `json:"status"`
+}
+
+// ESGReport holds all GRI disclosures extracted from ESG content index tables.
+type ESGReport struct {
+	Disclosures []GRIDisclosure `json:"disclosures"`
+	Framework   string          `json:"framework"`
+}
+
+// ESGExtractor extracts GRI content index data from parsed tables.
+type ESGExtractor struct{}
+
+// NewESGExtractor creates a new ESGExtractor.
+func NewESGExtractor() *ESGExtractor {
+	return &ESGExtractor{}
+}
+
+// Extract scans the provided tables for GRI content index data and returns an
+// ESGReport. Tables without GRI-related content are skipped. Returns nil if no
+// GRI disclosures are found.
+func (e *ESGExtractor) Extract(tables []table.Table) *ESGReport {
+	var disclosures []GRIDisclosure
+
+	for i := range tables {
+		if !isGRITable(tables[i]) {
+			continue
+		}
+
+		disclosures = append(disclosures, extractDisclosures(tables[i])...)
+	}
+
+	if len(disclosures) == 0 {
+		return nil
+	}
+
+	return &ESGReport{
+		Disclosures: disclosures,
+		Framework:   "GRI",
+	}
+}
+
+func isGRITable(t table.Table) bool {
+	if slices.ContainsFunc(t.Headers, containsGRI) {
+		return true
+	}
+
+	if len(t.Rows) > 0 {
+		for _, cell := range t.Rows[0].Cells {
+			if containsGRI(cell.Text) {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
+func containsGRI(text string) bool {
+	return strings.Contains(strings.ToUpper(text), "GRI")
+}
+
+func extractDisclosures(t table.Table) []GRIDisclosure {
+	var disclosures []GRIDisclosure
+
+	for _, row := range t.Rows {
+		disclosure, ok := parseDisclosureRow(row)
+		if ok {
+			disclosures = append(disclosures, disclosure)
+		}
+	}
+
+	return disclosures
+}
+
+func parseDisclosureRow(row table.Row) (GRIDisclosure, bool) {
+	if len(row.Cells) == 0 {
+		return GRIDisclosure{}, false
+	}
+
+	number := extractDisclosureNumber(row)
+	if number == "" {
+		return GRIDisclosure{}, false
+	}
+
+	disclosure := GRIDisclosure{
+		Number: number,
+	}
+
+	assignDisclosureFields(&disclosure, row)
+
+	return disclosure, true
+}
+
+func extractDisclosureNumber(row table.Row) string {
+	for _, cell := range row.Cells {
+		match := griPattern.FindStringSubmatch(cell.Text)
+		if match != nil {
+			return match[1]
+		}
+	}
+
+	return ""
+}
+
+func assignDisclosureFields(d *GRIDisclosure, row table.Row) {
+	cells := row.Cells
+	numIdx := findDisclosureNumberIndex(cells)
+
+	// Assign description from cells adjacent to the disclosure number.
+	for i, cell := range cells {
+		if i == numIdx {
+			continue
+		}
+
+		text := strings.TrimSpace(cell.Text)
+		if text == "" {
+			continue
+		}
+
+		if isPageReference(text) {
+			d.PageRef = text
+
+			continue
+		}
+
+		if status := detectStatus(text); status != "" {
+			d.Status = status
+
+			continue
+		}
+
+		// First non-number text cell becomes the title, second becomes
+		// the description.
+		if d.Title == "" {
+			d.Title = text
+		} else if d.Description == "" {
+			d.Description = text
+		}
+	}
+}
+
+func findDisclosureNumberIndex(cells []table.Cell) int {
+	for i, cell := range cells {
+		if griPattern.MatchString(cell.Text) {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func isPageReference(text string) bool {
+	trimmed := strings.TrimSpace(text)
+	if trimmed == "" {
+		return false
+	}
+
+	for _, r := range trimmed {
+		if (r < '0' || r > '9') && r != ',' && r != '-' && r != ' ' {
+			return false
+		}
+	}
+
+	return true
+}
+
+func detectStatus(text string) string {
+	lower := strings.ToLower(strings.TrimSpace(text))
+
+	switch {
+	case strings.Contains(lower, "partially reported"):
+		return StatusPartiallyReported
+	case strings.Contains(lower, "not reported"):
+		return StatusNotReported
+	case strings.Contains(lower, "reported"):
+		return StatusReported
+	}
+
+	return ""
+}

--- a/internal/domain/esg_test.go
+++ b/internal/domain/esg_test.go
@@ -1,0 +1,401 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/lugassawan/idxlens/internal/table"
+)
+
+func TestESGExtractorExtract(t *testing.T) {
+	extractor := NewESGExtractor()
+
+	tests := []struct {
+		name            string
+		tables          []table.Table
+		wantNil         bool
+		wantFramework   string
+		wantDisclosures []GRIDisclosure
+	}{
+		{
+			name:    "nil tables returns nil report",
+			tables:  nil,
+			wantNil: true,
+		},
+		{
+			name:    "empty tables returns nil report",
+			tables:  []table.Table{},
+			wantNil: true,
+		},
+		{
+			name: "table without GRI content returns nil report",
+			tables: []table.Table{
+				{
+					Headers: []string{"Item", "Amount", "Date"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "Revenue"},
+							{Text: "1,000,000"},
+							{Text: "2024"},
+						}},
+					},
+				},
+			},
+			wantNil: true,
+		},
+		{
+			name: "single GRI disclosure from header-identified table",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI Standard", "Disclosure", "Page"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "GRI 201-1"},
+							{Text: "Direct economic value generated"},
+							{Text: "45"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number:  "201-1",
+					Title:   "Direct economic value generated",
+					PageRef: "45",
+				},
+			},
+		},
+		{
+			name: "multiple disclosures from single table",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI Standard", "Title", "Description", "Page"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "GRI 302-1"},
+							{Text: "Energy consumption"},
+							{Text: "Energy within the organization"},
+							{Text: "78"},
+						}},
+						{Cells: []table.Cell{
+							{Text: "GRI 303-1"},
+							{Text: "Water withdrawal"},
+							{Text: "Interactions with water"},
+							{Text: "82"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number:      "302-1",
+					Title:       "Energy consumption",
+					Description: "Energy within the organization",
+					PageRef:     "78",
+				},
+				{
+					Number:      "303-1",
+					Title:       "Water withdrawal",
+					Description: "Interactions with water",
+					PageRef:     "82",
+				},
+			},
+		},
+		{
+			name: "disclosure number without GRI prefix",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI Index", "Topic"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "401-1"},
+							{Text: "New employee hires"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number: "401-1",
+					Title:  "New employee hires",
+				},
+			},
+		},
+		{
+			name: "GRI detected in first row cells when headers empty",
+			tables: []table.Table{
+				{
+					Headers: nil,
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "GRI Standard"},
+							{Text: "Disclosure Title"},
+						}},
+						{Cells: []table.Cell{
+							{Text: "GRI 205-1"},
+							{Text: "Anti-corruption policies"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number: "205-1",
+					Title:  "Anti-corruption policies",
+				},
+			},
+		},
+		{
+			name: "status detection in disclosure row",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI", "Topic", "Status"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "GRI 306-1"},
+							{Text: "Waste generation"},
+							{Text: "Reported"},
+						}},
+						{Cells: []table.Cell{
+							{Text: "GRI 306-2"},
+							{Text: "Waste management"},
+							{Text: "Partially Reported"},
+						}},
+						{Cells: []table.Cell{
+							{Text: "GRI 306-3"},
+							{Text: "Waste diverted"},
+							{Text: "Not Reported"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number: "306-1",
+					Title:  "Waste generation",
+					Status: StatusReported,
+				},
+				{
+					Number: "306-2",
+					Title:  "Waste management",
+					Status: StatusPartiallyReported,
+				},
+				{
+					Number: "306-3",
+					Title:  "Waste diverted",
+					Status: StatusNotReported,
+				},
+			},
+		},
+		{
+			name: "row without disclosure number is skipped",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI Standard", "Title"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "Economic Topics"},
+							{Text: ""},
+						}},
+						{Cells: []table.Cell{
+							{Text: "GRI 201-1"},
+							{Text: "Economic value"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number: "201-1",
+					Title:  "Economic value",
+				},
+			},
+		},
+		{
+			name: "empty row is skipped",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI Standard", "Title"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{}},
+						{Cells: []table.Cell{
+							{Text: "GRI 201-1"},
+							{Text: "Economic value"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number: "201-1",
+					Title:  "Economic value",
+				},
+			},
+		},
+		{
+			name: "multiple tables with mixed GRI and non-GRI content",
+			tables: []table.Table{
+				{
+					Headers: []string{"Item", "Amount"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "Revenue"},
+							{Text: "1,000,000"},
+						}},
+					},
+				},
+				{
+					Headers: []string{"GRI Standard", "Title", "Page"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "GRI 102-1"},
+							{Text: "Name of the organization"},
+							{Text: "5"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number:  "102-1",
+					Title:   "Name of the organization",
+					PageRef: "5",
+				},
+			},
+		},
+		{
+			name: "page reference with range",
+			tables: []table.Table{
+				{
+					Headers: []string{"GRI", "Title", "Page"},
+					Rows: []table.Row{
+						{Cells: []table.Cell{
+							{Text: "GRI 102-1"},
+							{Text: "Organization name"},
+							{Text: "5-7"},
+						}},
+					},
+				},
+			},
+			wantFramework: "GRI",
+			wantDisclosures: []GRIDisclosure{
+				{
+					Number:  "102-1",
+					Title:   "Organization name",
+					PageRef: "5-7",
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractor.Extract(tt.tables)
+
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("Extract() = %v, want nil", got)
+				}
+
+				return
+			}
+
+			if got == nil {
+				t.Fatal("Extract() returned nil, want non-nil report")
+			}
+
+			if got.Framework != tt.wantFramework {
+				t.Errorf("Framework = %q, want %q", got.Framework, tt.wantFramework)
+			}
+
+			assertDisclosures(t, got.Disclosures, tt.wantDisclosures)
+		})
+	}
+}
+
+func TestIsPageReference(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want bool
+	}{
+		{name: "single page number", text: "45", want: true},
+		{name: "page range", text: "45-47", want: true},
+		{name: "multiple pages", text: "45, 47", want: true},
+		{name: "text content", text: "Energy consumption", want: false},
+		{name: "empty string", text: "", want: false},
+		{name: "whitespace only", text: "   ", want: false},
+		{name: "mixed content", text: "page 45", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPageReference(tt.text); got != tt.want {
+				t.Errorf("isPageReference(%q) = %v, want %v", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{name: "reported", text: "Reported", want: StatusReported},
+		{name: "partially reported", text: "Partially Reported", want: StatusPartiallyReported},
+		{name: "not reported", text: "Not Reported", want: StatusNotReported},
+		{name: "case insensitive", text: "REPORTED", want: StatusReported},
+		{name: "with whitespace", text: "  reported  ", want: StatusReported},
+		{name: "no status", text: "Energy consumption", want: ""},
+		{name: "empty string", text: "", want: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := detectStatus(tt.text); got != tt.want {
+				t.Errorf("detectStatus(%q) = %q, want %q", tt.text, got, tt.want)
+			}
+		})
+	}
+}
+
+func assertDisclosures(t *testing.T, got, want []GRIDisclosure) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("got %d disclosures, want %d", len(got), len(want))
+	}
+
+	for i, w := range want {
+		g := got[i]
+
+		if g.Number != w.Number {
+			t.Errorf("disclosure[%d].Number = %q, want %q", i, g.Number, w.Number)
+		}
+
+		if g.Title != w.Title {
+			t.Errorf("disclosure[%d].Title = %q, want %q", i, g.Title, w.Title)
+		}
+
+		if g.Description != w.Description {
+			t.Errorf("disclosure[%d].Description = %q, want %q", i, g.Description, w.Description)
+		}
+
+		if g.PageRef != w.PageRef {
+			t.Errorf("disclosure[%d].PageRef = %q, want %q", i, g.PageRef, w.PageRef)
+		}
+
+		if g.Status != w.Status {
+			t.Errorf("disclosure[%d].Status = %q, want %q", i, g.Status, w.Status)
+		}
+	}
+}


### PR DESCRIPTION
## Issue
Closes #25

## Summary
- Add `ESGExtractor` in `internal/domain/esg.go` that parses GRI content index tables into structured `GRIDisclosure` data
- Supports disclosure number extraction (regex `\d{3}-\d+`), title, description, page references, and status detection (reported/partially reported/not reported)
- Identifies GRI tables by scanning headers and first-row cells for "GRI" keyword

## Test Plan
- [x] Linter passes (`make lint`)
- [x] All tests pass (`make test`)
- [x] 12 table-driven test cases covering: nil/empty tables, non-GRI tables, single/multiple disclosures, status detection, page reference formats, mixed GRI and non-GRI tables, empty rows, missing columns
- [x] Unit tests for `isPageReference` and `detectStatus` helpers

## Notes
- Layer L3 (domain) — imports only L2 (`internal/table`) and stdlib
- No error return from `Extract` since extraction is best-effort; returns `nil` when no GRI disclosures found