### PR TITLE
docs: add documentation site

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,171 @@
+# Architecture
+
+IDXLens processes PDF files through a six-layer pipeline. Each layer has a single responsibility and communicates with adjacent layers through interfaces.
+
+## Layer overview
+
+```
+┌─────────────────────────────────────────────┐
+│  Framework: cmd/idxlens/main.go             │  Calls cli.Execute()
+├─────────────────────────────────────────────┤
+│  L5  CLI             internal/cli/          │  Cobra commands, flag parsing
+├─────────────────────────────────────────────┤
+│  L4  Output          internal/output/       │  JSON/CSV formatting
+├─────────────────────────────────────────────┤
+│  L3  Domain          internal/domain/       │  Classification, mapping, dictionaries
+├─────────────────────────────────────────────┤
+│  L2  Table           internal/table/        │  Table detection from layout
+├─────────────────────────────────────────────┤
+│  L1  Layout          internal/layout/       │  Text grouping, line detection
+├─────────────────────────────────────────────┤
+│  L0  PDF             internal/pdf/          │  Raw PDF parsing (pdfcpu)
+└─────────────────────────────────────────────┘
+```
+
+## Dependency rule
+
+Dependencies flow strictly downward. Each layer may only import from layers below it:
+
+```
+cli -> output -> domain -> table -> layout -> pdf
+```
+
+No layer imports from a layer above it. This keeps the architecture testable and maintainable -- lower layers can be tested in isolation without any knowledge of how they are consumed.
+
+## Layer details
+
+### L0: PDF Parser (`internal/pdf/`)
+
+Wraps the [pdfcpu](https://github.com/pdfcpu/pdfcpu) library to extract raw text content from PDF pages. Provides a `Reader` interface for opening PDFs and iterating over pages.
+
+**Interface:**
+
+```go
+type Reader interface {
+    Open(r io.ReadSeeker) error
+    Close() error
+    PageCount() int
+    ReadPage(pageNum int) (Page, error)
+}
+```
+
+**Responsibilities:**
+- Open and validate PDF files
+- Extract raw text elements with position coordinates
+- Provide page-level access to content
+
+### L1: Text and Layout Engine (`internal/layout/`)
+
+Transforms raw PDF text elements into structured layout pages with text lines, blocks, and spatial relationships.
+
+**Interface:**
+
+```go
+type Analyzer interface {
+    Analyze(page pdf.Page) (LayoutPage, error)
+}
+```
+
+**Responsibilities:**
+- Group text elements into lines based on vertical proximity
+- Sort elements within lines by horizontal position
+- Build a spatial model of the page content
+
+### L2: Table Detector (`internal/table/`)
+
+Identifies tabular structures in layout pages by detecting aligned columns, row boundaries, and header regions.
+
+**Responsibilities:**
+- Detect table boundaries within layout pages
+- Extract headers and data rows
+- Handle multi-column layouts common in financial reports
+
+### L3: IDX Domain Engine (`internal/domain/`)
+
+Contains all IDX-specific business logic: document classification, financial statement mapping, number parsing, and dictionary-based label matching.
+
+**Key components:**
+
+| Component          | Purpose                                                  |
+|-------------------|----------------------------------------------------------|
+| Classifier         | Heuristic-based report type detection                    |
+| Mapper             | Maps table rows to financial line items using dictionaries|
+| Dictionary         | Bilingual label matching (Indonesian/English)            |
+| Number parser      | Indonesian number format parsing (dot thousands, comma decimal) |
+
+**Responsibilities:**
+- Classify documents by type (balance sheet, income statement, etc.)
+- Map raw table data to structured financial statements
+- Match labels to dictionary items with confidence scores
+- Parse Indonesian-format numbers
+
+### L4: Output Formatter (`internal/output/`)
+
+Formats financial statements into output formats (JSON, CSV).
+
+**Interface:**
+
+```go
+type Formatter interface {
+    Format(w io.Writer, stmt *domain.FinancialStatement) error
+}
+```
+
+**Responsibilities:**
+- Serialize financial statements to JSON (with optional pretty-printing)
+- Serialize financial statements to CSV with sorted period columns
+
+### L5: CLI (`internal/cli/`)
+
+Cobra-based command definitions. Wires the pipeline together, handles flag parsing, and manages I/O.
+
+**Responsibilities:**
+- Define commands (`classify`, `extract financial`, `extract text`, `version`)
+- Parse and validate flags
+- Orchestrate the pipeline: open PDF, analyze, classify, detect tables, map, format
+- Handle output destination (stdout or file)
+
+## Interface boundaries
+
+Each layer defines its interfaces at its own boundary. Implementations live in the layer below. This follows the Dependency Inversion Principle -- upper layers depend on abstractions, not concrete implementations.
+
+```
+L5 cli/        uses    output.Formatter (interface defined in L4)
+L4 output/     uses    domain.FinancialStatement (types defined in L3)
+L3 domain/     uses    table.Table (types defined in L2)
+L2 table/      uses    layout.LayoutPage (types defined in L1)
+L1 layout/     uses    pdf.Page (types defined in L0)
+```
+
+## Data flow
+
+A typical `extract financial` command flows through all layers:
+
+```
+PDF file
+  │
+  ▼
+L0 pdf.Reader.ReadPage()        →  pdf.Page (raw text + positions)
+  │
+  ▼
+L1 layout.Analyzer.Analyze()    →  layout.LayoutPage (structured lines)
+  │
+  ▼
+L3 domain.Classifier.Classify() →  domain.Classification (report type)
+  │
+  ▼
+L2 table.Detector.Detect()      →  []table.Table (headers + rows)
+  │
+  ▼
+L3 domain.Mapper.Map()          →  domain.FinancialStatement (structured data)
+  │
+  ▼
+L4 output.Formatter.Format()    →  JSON or CSV output
+```
+
+## Design principles
+
+- **Pure Go, no CGO**: Single static binary with no external dependencies at runtime
+- **No network calls**: All processing is local. PDF in, data out.
+- **Internal only**: All packages live under `internal/` -- no public API surface
+- **Interface-driven**: Cross-layer boundaries use interfaces for testability and decoupling

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,164 @@
+# CLI Reference
+
+IDXLens provides commands for classifying and extracting data from IDX PDF reports.
+
+## Global
+
+```
+idxlens [command]
+```
+
+IDXLens is a CLI tool for extracting structured financial data from Indonesia Stock Exchange (IDX) PDF reports. It converts unstructured PDF tables into clean, machine-readable formats.
+
+## Commands
+
+### `version`
+
+Print version information.
+
+```sh
+idxlens version
+```
+
+Output includes version tag, commit hash, and build timestamp.
+
+---
+
+### `classify`
+
+Classify an IDX PDF report by type. Analyzes the first few pages to determine the report type using heuristic matching.
+
+```sh
+idxlens classify [pdf-path]
+```
+
+**Arguments:**
+
+| Argument   | Description              |
+|-----------|--------------------------|
+| `pdf-path` | Path to the PDF file     |
+
+**Flags:**
+
+| Flag              | Short | Default | Description                    |
+|-------------------|-------|---------|--------------------------------|
+| `--format`        | `-f`  | `text`  | Output format (`text`, `json`) |
+
+**Examples:**
+
+```sh
+# Text output (default)
+idxlens classify report.pdf
+
+# JSON output
+idxlens classify report.pdf --format json
+```
+
+**Text output:**
+
+```
+Type:       balance-sheet
+Confidence: 95%
+Language:   id
+```
+
+**JSON output:**
+
+```json
+{
+  "type": "balance-sheet",
+  "confidence": 0.95,
+  "language": "id"
+}
+```
+
+**Supported report types:**
+
+| Type                | Description                      |
+|---------------------|----------------------------------|
+| `balance-sheet`     | Statement of Financial Position  |
+| `income-statement`  | Statement of Profit or Loss      |
+| `cash-flow`         | Statement of Cash Flows          |
+| `equity-changes`    | Statement of Changes in Equity   |
+
+---
+
+### `extract`
+
+Parent command for data extraction subcommands.
+
+```sh
+idxlens extract [subcommand]
+```
+
+---
+
+### `extract financial`
+
+Extract structured financial data from an IDX PDF report. Runs the full L0-L4 pipeline: PDF parsing, layout analysis, document classification, table detection, financial statement mapping, and output formatting.
+
+```sh
+idxlens extract financial [pdf-path]
+```
+
+**Arguments:**
+
+| Argument   | Description              |
+|-----------|--------------------------|
+| `pdf-path` | Path to the PDF file     |
+
+**Flags:**
+
+| Flag              | Short | Default | Description                                              |
+|-------------------|-------|---------|----------------------------------------------------------|
+| `--type`          | `-t`  | (auto)  | Report type (e.g. `balance-sheet`, `income-statement`)   |
+| `--format`        | `-f`  | `json`  | Output format (`json`, `csv`)                            |
+| `--output`        | `-o`  | stdout  | Output file path                                         |
+| `--pretty`        |       | `false` | Pretty-print output (JSON only)                          |
+
+When `--type` is omitted, IDXLens auto-classifies the document. If classification fails, use `--type` to specify it explicitly.
+
+**Examples:**
+
+```sh
+# Auto-detect type, output JSON to stdout
+idxlens extract financial report.pdf
+
+# Specify type, pretty JSON
+idxlens extract financial report.pdf --type balance-sheet --pretty
+
+# CSV output to file
+idxlens extract financial report.pdf --format csv --output data.csv
+```
+
+---
+
+### `extract text`
+
+Extract text lines from a PDF by running the L0 (PDF parser) and L1 (layout analyzer) pipeline. Outputs one text line per line, grouped by page.
+
+```sh
+idxlens extract text [pdf-path]
+```
+
+**Arguments:**
+
+| Argument   | Description              |
+|-----------|--------------------------|
+| `pdf-path` | Path to the PDF file     |
+
+**Flags:**
+
+| Flag       | Short | Default   | Description                           |
+|-----------|-------|-----------|---------------------------------------|
+| `--pages` |       | all pages | Page range (e.g. `"1-3,5,7-9"`)      |
+
+**Examples:**
+
+```sh
+# Extract all pages
+idxlens extract text report.pdf
+
+# Extract specific pages
+idxlens extract text report.pdf --pages "1-3,5"
+```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,177 @@
+# Contributing
+
+## Prerequisites
+
+- [Go](https://go.dev/) 1.26+
+- [mise](https://mise.jdx.dev/) for tool version management
+- [golangci-lint](https://golangci-lint.run/) v2 (installed via mise)
+
+## Development setup
+
+```sh
+git clone https://github.com/lugassawan/idxlens.git
+cd idxlens
+make init
+```
+
+`make init` does the following:
+
+1. Trusts and installs mise tool versions (Go, golangci-lint, golines)
+2. Builds the custom linter binary (`custom-gcl`)
+3. Configures git to use `.githooks/` for hooks
+
+## Available commands
+
+| Command          | Description                                     |
+|------------------|-------------------------------------------------|
+| `make build`     | Build binary to `bin/idxlens`                   |
+| `make lint`      | Build custom linter and run golangci-lint        |
+| `make fmt`       | Auto-format code (gofmt + golines)              |
+| `make test`      | Run all tests                                   |
+| `make coverage`  | Generate coverage report to `coverage/`         |
+| `make clean`     | Remove build artifacts                          |
+
+## Code style
+
+- Standard Go conventions: `gofmt` formatting, tab indentation, MixedCaps naming
+- Maximum line length: 120 characters (enforced by golines)
+- All packages live under `internal/` -- no public API surface
+- Error wrapping: `fmt.Errorf("context: %w", err)`
+
+## Testing
+
+- Use the standard library `testing` package only (no testify)
+- Write table-driven tests with `t.Run()` subtests
+- Place test files alongside source files (`*_test.go`)
+- Run tests: `make test` or `go test ./...`
+- Generate coverage: `make coverage`
+
+Example test structure:
+
+```go
+func TestSomething(t *testing.T) {
+    tests := []struct {
+        name string
+        input string
+        want  string
+    }{
+        {name: "basic case", input: "a", want: "b"},
+        {name: "edge case", input: "", want: ""},
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            got := doSomething(tt.input)
+            if got != tt.want {
+                t.Errorf("doSomething(%q) = %q, want %q", tt.input, got, tt.want)
+            }
+        })
+    }
+}
+```
+
+## Custom linter
+
+IDXLens uses a custom golangci-lint v2 plugin called [tidygo](https://github.com/lugassawan/tidygo) with five analyzers:
+
+| Analyzer         | Rule                                                     |
+|-----------------|----------------------------------------------------------|
+| `funcname`       | No underscores in function names                         |
+| `maxparams`      | No more than 7 function parameters                       |
+| `nolateconst`    | Package-level const/var must appear before functions     |
+| `nolocalstruct`  | No named struct declarations inside function bodies      |
+| `nolateexport`   | Exported standalone functions must appear before unexported ones |
+
+Always fix lint issues at the root cause. Only use `//nolint` as a last resort with a justification comment.
+
+## Branching and commits
+
+### Branch naming
+
+Use prefixed branch names:
+
+- `feat/` -- new features
+- `fix/` -- bug fixes
+- `chore/` -- maintenance, tooling, documentation
+- `docs/` -- documentation changes
+
+### Commit messages
+
+Follow the `type: description` format. Valid types:
+
+| Type       | Use for                              |
+|-----------|--------------------------------------|
+| `feat`     | New features                         |
+| `fix`      | Bug fixes                            |
+| `docs`     | Documentation changes                |
+| `refactor` | Code restructuring (no behavior change) |
+| `test`     | Adding or updating tests             |
+| `build`    | Build system and dependencies        |
+| `ci`       | CI/CD configuration                  |
+| `chore`    | Maintenance and tooling              |
+| `revert`   | Reverting a previous commit          |
+
+Rules:
+
+- No scopes: `feat: add classifier` (not `feat(domain): add classifier`)
+- No breaking change marker: `feat: new api` (not `feat!: new api`)
+- Enforced by `.githooks/commit-msg`
+
+### Commit splitting
+
+Split changes into logical commits. Separate:
+
+- Infrastructure/config changes
+- Core logic
+- Tests
+- Wiring/integration
+
+Never bundle unrelated changes into a single commit.
+
+## Pull requests
+
+### Direct commits to main/master are blocked
+
+The pre-commit hook prevents direct commits to the main branch. Always work on a feature branch.
+
+### PR title
+
+Use the same `type: description` format as commit messages.
+
+### PR body
+
+Follow the template in `.github/pull_request_template.md`:
+
+```markdown
+## Issue
+Closes #123
+
+## Summary
+- What changed and why
+
+## Test Plan
+- [ ] Linter passes (`make lint`)
+- [ ] Tests pass (`make test`)
+
+## Notes
+Optional context for reviewers.
+```
+
+### Before submitting
+
+1. Run the full verification suite:
+   ```sh
+   make fmt
+   make lint
+   make test
+   ```
+2. Ensure all checks pass
+3. Push your branch and open a PR
+
+## Architecture
+
+See [architecture.md](architecture.md) for the layer structure. Key rules:
+
+- Dependencies flow downward only: `cli -> output -> domain -> table -> layout -> pdf`
+- Cross-layer boundaries use interfaces
+- All logic lives in `internal/`

--- a/docs/dictionaries.md
+++ b/docs/dictionaries.md
@@ -1,0 +1,135 @@
+# Dictionaries
+
+IDXLens uses JSON dictionary files to map financial line item labels found in PDFs to standardized keys. Dictionaries support bilingual labels (Indonesian and English) to handle both language variants common in IDX reports.
+
+## Location
+
+Dictionary files are embedded into the binary at build time from:
+
+```
+internal/domain/dictionaries/
+├── balance_sheet.json
+├── cash_flow.json
+├── equity_changes.json
+└── income_statement.json
+```
+
+Each file corresponds to a report type.
+
+## JSON format
+
+A dictionary file has this structure:
+
+```json
+{
+  "type": "balance-sheet",
+  "version": 2,
+  "items": [
+    {
+      "key": "cash_and_equivalents",
+      "labels": {
+        "id": ["Kas dan Setara Kas", "Kas dan Bank"],
+        "en": ["Cash and Cash Equivalents", "Cash and Banks"]
+      },
+      "section": "assets",
+      "level": 2
+    }
+  ]
+}
+```
+
+### Top-level fields
+
+| Field     | Type   | Description                                    |
+|-----------|--------|------------------------------------------------|
+| `type`    | string | Report type identifier (e.g. `"balance-sheet"`)|
+| `version` | int    | Schema version for the dictionary              |
+| `items`   | array  | List of line item definitions                  |
+
+### Item fields
+
+| Field     | Type              | Description                                           |
+|-----------|-------------------|-------------------------------------------------------|
+| `key`     | string            | Unique identifier for the line item (snake_case)      |
+| `labels`  | map[string][]string | Language-keyed label variants for matching            |
+| `section` | string            | Logical section within the statement                  |
+| `level`   | int               | Nesting depth (0 = top-level, 1 = section, 2 = item) |
+
+### Label matching
+
+The `labels` field maps language codes to arrays of string variants:
+
+- `"id"` -- Indonesian labels
+- `"en"` -- English labels
+
+Multiple variants per language handle differences in casing, abbreviation, or phrasing across different company reports. The matcher compares extracted text against all variants and returns the best match with a confidence score:
+
+| Confidence | Match type                            |
+|-----------|---------------------------------------|
+| 1.0        | Exact string match                    |
+| 0.9        | Case-insensitive match                |
+| 0.7        | Label is a substring of the text      |
+
+## Adding custom items
+
+To add a new line item to an existing dictionary:
+
+1. Open the dictionary file in `internal/domain/dictionaries/`.
+2. Add a new entry to the `items` array:
+
+```json
+{
+  "key": "short_term_investments",
+  "labels": {
+    "id": ["Investasi Jangka Pendek"],
+    "en": ["Short-term Investments", "Short Term Investments"]
+  },
+  "section": "assets",
+  "level": 2
+}
+```
+
+3. Choose a descriptive `key` in snake_case. This becomes the field name in output.
+4. Include as many label variants as you find across different company reports.
+5. Set `section` to match the statement section (e.g. `"assets"`, `"liabilities"`, `"equity"`).
+6. Set `level` to reflect the nesting depth in the statement hierarchy.
+7. Rebuild the binary (`make build`) to embed the updated dictionary.
+
+## Report types and sections
+
+### Balance Sheet (`balance_sheet.json`)
+
+| Section       | Description                         |
+|--------------|-------------------------------------|
+| `assets`      | Current and non-current assets     |
+| `liabilities` | Current and non-current liabilities|
+| `equity`      | Shareholders' equity               |
+
+### Income Statement (`income_statement.json`)
+
+| Section       | Description                        |
+|--------------|------------------------------------|
+| `revenue`     | Revenue and sales                  |
+| `expenses`    | Cost of goods sold, operating expenses |
+| `profit`      | Gross, operating, and net profit   |
+
+### Cash Flow (`cash_flow.json`)
+
+| Section        | Description                       |
+|---------------|-----------------------------------|
+| `operating`    | Cash flows from operating activities |
+| `investing`    | Cash flows from investing activities |
+| `financing`    | Cash flows from financing activities |
+
+### Equity Changes (`equity_changes.json`)
+
+| Section        | Description                       |
+|---------------|-----------------------------------|
+| `equity`       | Changes in equity components      |
+
+## Guidelines for label variants
+
+- Include the exact text as it appears in PDFs (preserving casing).
+- Add both formal and abbreviated forms (e.g. "Jumlah Aset Lancar" and "Total Aset Lancar").
+- Add all-caps variants if commonly seen (e.g. "TOTAL ASSETS").
+- Test new labels against sample PDFs using `idxlens extract text` to see the raw text first.

--- a/docs/examples/basic-extraction.md
+++ b/docs/examples/basic-extraction.md
@@ -1,0 +1,139 @@
+# Basic Extraction
+
+This guide walks through common extraction workflows with IDXLens.
+
+## Classify a report first
+
+Before extracting data, you can check what type of report a PDF contains:
+
+```sh
+idxlens classify quarterly-report.pdf
+```
+
+```
+Type:       balance-sheet
+Confidence: 95%
+Language:   id
+```
+
+For machine-readable output:
+
+```sh
+idxlens classify quarterly-report.pdf --format json
+```
+
+```json
+{
+  "type": "balance-sheet",
+  "confidence": 0.95,
+  "language": "id"
+}
+```
+
+## Extract financial data
+
+### Auto-detect report type
+
+```sh
+idxlens extract financial quarterly-report.pdf
+```
+
+IDXLens classifies the document automatically and extracts structured data. The output is JSON by default.
+
+### Specify report type explicitly
+
+If auto-classification does not produce the expected result, specify the type:
+
+```sh
+idxlens extract financial quarterly-report.pdf --type income-statement
+```
+
+Available types: `balance-sheet`, `income-statement`, `cash-flow`, `equity-changes`.
+
+### Pretty-print JSON
+
+```sh
+idxlens extract financial quarterly-report.pdf --pretty
+```
+
+Sample output:
+
+```json
+{
+  "type": "balance-sheet",
+  "company": "PT Example Tbk",
+  "periods": ["2024-12-31", "2023-12-31"],
+  "currency": "IDR",
+  "unit": "millions",
+  "language": "id",
+  "items": [
+    {
+      "key": "total_assets",
+      "label": "Jumlah Aset",
+      "section": "assets",
+      "level": 0,
+      "confidence": 1.0,
+      "values": {
+        "2024-12-31": 50000000,
+        "2023-12-31": 45000000
+      }
+    }
+  ]
+}
+```
+
+### Export to CSV
+
+```sh
+idxlens extract financial quarterly-report.pdf --format csv --output data.csv
+```
+
+The CSV includes columns for label, key, section, and one column per period.
+
+## Extract raw text
+
+Use `extract text` to inspect what text IDXLens sees in the PDF. This is useful for debugging or understanding why a label is not matching a dictionary entry.
+
+### All pages
+
+```sh
+idxlens extract text quarterly-report.pdf
+```
+
+### Specific pages
+
+```sh
+idxlens extract text quarterly-report.pdf --pages "2-4"
+```
+
+### Single page
+
+```sh
+idxlens extract text quarterly-report.pdf --pages "1"
+```
+
+## Combine with other tools
+
+### Pipe JSON to jq
+
+```sh
+idxlens extract financial report.pdf | jq '.items[] | select(.section == "assets")'
+```
+
+### Extract a single field
+
+```sh
+idxlens extract financial report.pdf | jq -r '.company'
+```
+
+### Count line items
+
+```sh
+idxlens extract financial report.pdf | jq '.items | length'
+```
+
+### Filter by confidence
+
+```sh
+idxlens extract financial report.pdf | jq '.items[] | select(.confidence >= 0.9)'
+```

--- a/docs/examples/batch-processing.md
+++ b/docs/examples/batch-processing.md
@@ -1,0 +1,92 @@
+# Batch Processing
+
+IDXLens processes one PDF per invocation. For batch workflows, use shell scripting to process multiple files.
+
+## Process all PDFs in a directory
+
+```sh
+for pdf in reports/*.pdf; do
+    echo "Processing: $pdf"
+    idxlens extract financial "$pdf" --output "${pdf%.pdf}.json"
+done
+```
+
+This creates a `.json` file alongside each `.pdf` file.
+
+## Process with CSV output
+
+```sh
+for pdf in reports/*.pdf; do
+    idxlens extract financial "$pdf" --format csv --output "${pdf%.pdf}.csv"
+done
+```
+
+## Classify all reports first
+
+Before extracting, classify all PDFs to understand what you have:
+
+```sh
+for pdf in reports/*.pdf; do
+    type=$(idxlens classify "$pdf" --format json | jq -r '.type')
+    confidence=$(idxlens classify "$pdf" --format json | jq -r '.confidence')
+    echo "$pdf: $type ($confidence)"
+done
+```
+
+## Process only specific report types
+
+Extract only balance sheets from a directory of mixed reports:
+
+```sh
+for pdf in reports/*.pdf; do
+    type=$(idxlens classify "$pdf" --format json | jq -r '.type')
+    if [ "$type" = "balance-sheet" ]; then
+        idxlens extract financial "$pdf" --type balance-sheet --output "${pdf%.pdf}.json"
+    fi
+done
+```
+
+## Parallel processing
+
+Use `xargs` to process multiple files in parallel:
+
+```sh
+find reports/ -name "*.pdf" | xargs -P 4 -I {} sh -c '
+    idxlens extract financial "{}" --output "{}.json"
+'
+```
+
+The `-P 4` flag runs up to 4 processes in parallel.
+
+## Merge results
+
+Combine multiple JSON outputs into a single array:
+
+```sh
+jq -s '.' reports/*.json > combined.json
+```
+
+## Error handling
+
+Skip files that fail and log errors:
+
+```sh
+for pdf in reports/*.pdf; do
+    if ! idxlens extract financial "$pdf" --output "${pdf%.pdf}.json" 2>>"errors.log"; then
+        echo "FAILED: $pdf" | tee -a errors.log
+    fi
+done
+```
+
+## Summary report
+
+Generate a summary of all processed files:
+
+```sh
+for json in reports/*.json; do
+    company=$(jq -r '.company // "unknown"' "$json")
+    type=$(jq -r '.type' "$json")
+    items=$(jq '.items | length' "$json")
+    echo "$json: $company ($type, $items items)"
+done
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,122 @@
+# Getting Started
+
+IDXLens is a CLI tool for extracting structured financial data from Indonesia Stock Exchange (IDX) PDF reports. It converts unstructured PDF tables into clean, machine-readable JSON or CSV.
+
+## Installation
+
+### Using `go install`
+
+```sh
+go install github.com/lugassawan/idxlens/cmd/idxlens@latest
+```
+
+This installs the `idxlens` binary to your `$GOPATH/bin` directory.
+
+### Binary download
+
+Download a prebuilt binary from the [GitHub Releases](https://github.com/lugassawan/idxlens/releases) page. Binaries are available for:
+
+| OS      | Architecture |
+|---------|-------------|
+| Linux   | amd64, arm64 |
+| macOS   | amd64, arm64 |
+| Windows | amd64        |
+
+Extract the archive and place the `idxlens` binary somewhere in your `$PATH`.
+
+### Build from source
+
+```sh
+git clone https://github.com/lugassawan/idxlens.git
+cd idxlens
+make build
+```
+
+The binary is written to `bin/idxlens`.
+
+## Verify installation
+
+```sh
+idxlens version
+```
+
+Expected output:
+
+```
+idxlens v0.1.0 (commit: abc1234, built: 2025-01-01T00:00:00Z)
+```
+
+## Quick start
+
+### Classify a report
+
+Identify what type of financial report a PDF contains:
+
+```sh
+idxlens classify report.pdf
+```
+
+Output:
+
+```
+Type:       balance-sheet
+Confidence: 95%
+Language:   id
+```
+
+### Extract financial data
+
+Extract structured financial data from a PDF:
+
+```sh
+idxlens extract financial report.pdf
+```
+
+This runs the full pipeline (PDF parsing, layout analysis, classification, table detection, financial mapping) and outputs JSON to stdout.
+
+### Specify report type
+
+If auto-classification is not needed or gives unexpected results, specify the type explicitly:
+
+```sh
+idxlens extract financial report.pdf --type balance-sheet
+```
+
+### Change output format
+
+```sh
+# JSON (default)
+idxlens extract financial report.pdf --format json
+
+# Pretty-printed JSON
+idxlens extract financial report.pdf --format json --pretty
+
+# CSV
+idxlens extract financial report.pdf --format csv
+```
+
+### Save to a file
+
+```sh
+idxlens extract financial report.pdf --output result.json
+```
+
+### Extract raw text
+
+Extract text lines from a PDF without financial parsing:
+
+```sh
+idxlens extract text report.pdf
+```
+
+Extract specific pages:
+
+```sh
+idxlens extract text report.pdf --pages "1-3,5"
+```
+
+## Next steps
+
+- [CLI Reference](cli-reference.md) -- all commands and flags
+- [Architecture](architecture.md) -- how the processing pipeline works
+- [Examples](examples/basic-extraction.md) -- detailed usage examples


### PR DESCRIPTION
## Issue
Closes #34

## Summary
- Add documentation site with 7 Markdown files covering installation, CLI reference, architecture, dictionaries, contributing guidelines, and usage examples
- Documentation is plain Markdown with no static site generator dependency

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] All documentation files render correctly on GitHub

## Notes
Documentation files created:
- `docs/getting-started.md` -- installation and quick start
- `docs/cli-reference.md` -- all commands and flags
- `docs/architecture.md` -- L0-L5 layer architecture
- `docs/dictionaries.md` -- dictionary JSON format and customization
- `docs/contributing.md` -- dev setup, testing, PR process, commit conventions
- `docs/examples/basic-extraction.md` -- basic usage examples
- `docs/examples/batch-processing.md` -- shell-based batch workflows