### PR TITLE
build: add PyPI publishing workflow

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -16,19 +16,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-go@v5
+      - uses: jdx/mise-action@v2
         with:
-          go-version: "1.26"
+          install: true
 
       - name: Build CGo shared library
         run: |
           CGO_ENABLED=1 go build -buildmode=c-shared \
             -o bindings/python/idxlens/libidxlens.so \
             ./bindings/cgo/
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.x"
 
       - name: Build wheel
         run: |

--- a/.mise.toml
+++ b/.mise.toml
@@ -2,3 +2,4 @@
 go = "1.26"
 golangci-lint = "2"
 golines = "0.13"
+python = "3.12"


### PR DESCRIPTION
## Issue
Closes #29

## Summary
- Add `.github/workflows/pypi.yml` for building and publishing Python wheels to PyPI on tag push (`v*`)
- Build wheels across ubuntu, macos, and windows using CGo shared library + `python -m build`
- Publish to PyPI using trusted publishing (`pypa/gh-action-pypi-publish` with OIDC `id-token`)

## Test Plan
- [x] Linter passes (`make lint`)
- [x] Tests pass (`make test`)
- [x] Workflow YAML is valid and follows existing conventions from `release.yml`

## Notes
- No Go code changes -- workflow YAML only
- Requires a `pypi` environment configured in GitHub repo settings for trusted publishing