### PR TITLE
docs: update documentation for v1.1.3 release

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,8 @@ idxlens/
 ├── cmd/idxlens/        # Entry point (main.go calls cli.Execute())
 ├── internal/
 │   ├── cli/            # Cobra CLI commands (auth, list, fetch, extract, analyze, upgrade, version)
-│   ├── service/        # Orchestration service (registry, presentation extraction)
-│   ├── idx/            # IDX API client (auth, listing, fetching, downloading)
+│   ├── service/        # Orchestration service (registry, presentation extraction, analyze pipeline)
+│   ├── idx/            # IDX API client (auth, listing, fetching, downloading, retry)
 │   ├── upgrade/        # Self-update from GitHub Releases
 │   ├── safefile/       # Atomic file write utilities
 │   ├── xlsx/           # XLSX parser (excelize-based financial statement extraction)
@@ -42,11 +42,15 @@ idxlens/
 
 - All logic in `internal/` — no public API surface
 - Extraction pipeline: `cli/` -> `service/` -> `idx/`/`xlsx/`/`xbrl/` -> (IDX API or local files)
+- Extractor registry: `cli/extractor.go` defines `Extractor` interface + `map[string]Extractor` registry (OCP pattern)
+- Analyze pipeline: `cli/analyze.go` (thin wrapper) -> `service/analyze.go` (`FetchForAnalyze`) -> `idx/` (fetch + retry)
 - Presentation extraction: `cli/` -> `service/` -> `domain/kvextractor` -> `layout/` -> `pdf/`
 - Self-update: `cli/` -> `upgrade/` -> GitHub Releases API
 - Atomic file writes: `idx/` and `upgrade/` use `safefile/` for safe downloads
+- HTTP retry: `idx/retry.go` wraps API calls with exponential backoff (3 attempts, retries on 429/5xx)
 - Each layer defines interfaces at its boundary; implementations live in the layer below
 - `cmd/idxlens/main.go` is Framework layer — it only calls `cli.Execute()`
+- Common flag helpers: `cli/flags.go` provides `registerYearPeriodFlags`, `registerOutputFlags`, `parseYearPeriodFlags`, `parseOutputFlags`
 - `IDXLENS_HOME` env var controls local cache directory (default: `~/.idxlens`)
 
 ## Commands
@@ -68,11 +72,22 @@ docker build -t idxlens .    # Build Docker image
 idxlens auth              # Authenticate with IDX portal (headless Chrome)
 idxlens list TICKER       # List available reports for a ticker
 idxlens fetch TICKER      # Download reports to local cache
+idxlens fetch TICKER --dry-run  # Preview files without downloading
 idxlens extract FILE      # Extract financial data from XLSX/XBRL/PDF
 idxlens analyze TICKER    # Full pipeline: fetch + extract (best format)
 idxlens upgrade           # Self-update from GitHub Releases
 idxlens version           # Print version information
 ```
+
+### Global Flags
+
+- `--verbose` — enable verbose output (slog-based structured logging to stderr)
+
+### Environment Variables
+
+- `IDXLENS_HOME` — local cache directory (default: `~/.idxlens`)
+- `IDXLENS_AUTH_TIMEOUT` — authentication timeout duration (default: `30s`, e.g. `60s`, `2m`)
+- `NO_COLOR` — disable colored output in banner
 
 ## Conventions
 
@@ -88,6 +103,7 @@ idxlens version           # Print version information
 - **Internal only**: All packages live under `internal/` — no public API surface
 - **Error wrapping**: Use `fmt.Errorf("context: %w", err)` for error chains
 - **Tests**: Table-driven tests with `t.Run()` subtests, standard `testing` package only (no testify)
+- **Environment variables**: All env var names are centralized as constants (`envHome` in `idx/home.go`, `envAuthTimeout` in `idx/auth.go`, `envNoColor` in `cli/constants.go`)
 - **IDXLENS_HOME**: Controls local cache directory (default: `~/.idxlens`); used by auth, fetch, and analyze commands
 - **Naming**: Standard Go naming conventions (MixedCaps, no underscores in names)
 

--- a/README.md
+++ b/README.md
@@ -18,11 +18,15 @@ IDXLens is a CLI tool that fetches and extracts structured financial data from I
 
 ## Features
 
-- **Authenticate** with IDX portal via headless Chrome
+- **Authenticate** with IDX portal via headless Chrome (with cookie expiry detection)
 - **List and fetch** available financial reports for any ticker
+- **Dry-run mode** (`fetch --dry-run`): preview files before downloading
 - **Extract financial data** from XLSX (excelize), XBRL (ZIP archives), and PDF presentations
 - **Full pipeline** (`analyze`): fetch if needed, then extract from the best available format (XBRL > XLSX > PDF)
 - **Presentation KV extraction** for corporate presentations (key-value pair detection from PDF layout)
+- **Automatic retry** with exponential backoff for transient API failures (429, 5xx)
+- **Verbose logging** (`--verbose`): structured debug output via `slog`
+- **ETag caching** for registry: conditional fetches skip re-downloading unchanged data
 - **Local caching** via `IDXLENS_HOME` (default: `~/.idxlens`)
 - **JSON output** with optional pretty-print
 - **Self-update** via `idxlens upgrade` from GitHub Releases
@@ -65,6 +69,9 @@ idxlens list BBCA -y 2024
 # Fetch reports to local cache
 idxlens fetch BBCA -y 2024 -p Q3
 
+# Preview files without downloading
+idxlens fetch BBCA -y 2024 --dry-run
+
 # Extract financial data from a local file
 idxlens extract path/to/report.xlsx --pretty
 idxlens extract path/to/report.zip   # XBRL ZIP
@@ -72,6 +79,9 @@ idxlens extract path/to/presentation.pdf --mode presentation
 
 # Full pipeline: fetch (if needed) + extract
 idxlens analyze BBCA -y 2024 -p Q3
+
+# Verbose output for debugging
+idxlens analyze BBCA -y 2024 --verbose
 
 # Self-update to latest version
 idxlens upgrade

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ IDXLens extracts structured financial data from IDX reports (XLSX, XBRL, PDF) wi
 ├─────────────────────────────────────────────────┤
 │  CLI              internal/cli/                 │  Cobra commands, flag parsing, IO
 ├─────────────────────────────────────────────────┤
-│  Service          internal/service/             │  Registry, presentation extraction
+│  Service          internal/service/             │  Registry, analyze pipeline, presentation extraction
 ├─────────────────────────────────────────────────┤
 │  IDX API          internal/idx/                 │  Auth, listing, fetching, downloading
 │  Upgrade          internal/upgrade/             │  GitHub Releases self-update
@@ -31,10 +31,11 @@ Dependencies flow strictly downward. Each layer may only import from layers belo
 Key dependency chains:
 
 ```
-cli -> service -> idx -> safefile
+cli -> service -> idx (with retry) -> safefile
 cli -> service -> {xlsx, xbrl}
 cli -> service -> domain -> layout -> pdf
 cli -> upgrade -> safefile
+cli -> extractor registry -> {xlsx, xbrl, service/presentation}
 ```
 
 ## Data flows
@@ -72,11 +73,11 @@ idxlens extract report.zip
 idxlens extract presentation.pdf --mode presentation
   │
   ▼
-cli/extract.go  →  service layer (format detection)
+cli/extract.go  →  extractor registry (format lookup)
   │
-  ├──  XLSX  →  xlsx.Parse()
-  ├──  XBRL  →  xbrl.Parse()
-  └──  PDF   →  domain/kvextractor  →  layout.Analyzer  →  pdf.Reader
+  ├──  xlsxExtractor  →  xlsx.Parse()
+  ├──  xbrlExtractor  →  xbrl.ParseZip()
+  └──  pdfExtractor   →  domain/kvextractor  →  layout.Analyzer  →  pdf.Reader
   │
   ▼
 JSON output (stdout or file)
@@ -88,10 +89,13 @@ JSON output (stdout or file)
 idxlens analyze BBCA -y 2024 -p Q3
   │
   ▼
-cli/analyze.go  →  idx.Client.Fetch() (if not cached)
+cli/analyze.go  →  service.FetchForAnalyze() (with retry + warning on failures)
   │
   ▼
-service layer  →  Try XBRL → XLSX → PDF (best available format)
+cli/analyze.go  →  bestFormat() → extractor registry
+  │
+  ▼
+Try XBRL → XLSX → PDF (best available format)
   │
   ▼
 JSON output
@@ -117,10 +121,17 @@ Cobra-based command definitions. Wires the pipeline together, handles flag parsi
 
 **Commands:** `auth`, `list`, `fetch`, `extract`, `analyze`, `upgrade`, `version`
 
+Key patterns:
+- **Flag helpers** (`flags.go`): Shared flag registration and parsing (`registerYearPeriodFlags`, `registerOutputFlags`, `parseYearPeriodFlags`, `parseOutputFlags`)
+- **Extractor registry** (`extractor.go`): `Extractor` interface + `map[string]Extractor` registry. Format-specific extractors (`xlsxExtractor`, `xbrlExtractor`, `pdfExtractor`) are registered at init time. New formats can be added without modifying the dispatch logic (Open-Closed Principle).
+- **Logger** (`logger.go`): `slog`-based structured logger, writes to stderr when `--verbose` is set, discards otherwise
+- **Dry-run**: `fetch --dry-run` lists files without downloading
+
 ### Service (`internal/service/`)
 
 Orchestration layer between CLI and lower packages.
 
+- **Analyze pipeline** (`analyze.go`): `FetchForAnalyze` handles report fetching with download failure warnings
 - **Registry provider**: Loads report registry data for presentation extraction
 - **Presentation extraction**: Coordinates the PDF pipeline (domain -> layout -> pdf)
 
@@ -128,10 +139,12 @@ Orchestration layer between CLI and lower packages.
 
 Client for the IDX portal API. Uses `NewAuthenticatedClient()` factory for session management.
 
-- **Auth**: Headless Chrome login via chromedp
+- **Auth**: Headless Chrome login via chromedp; cookie expiry detection (`CookiesValid`); configurable timeout via `IDXLENS_AUTH_TIMEOUT`
+- **Retry** (`retry.go`): Exponential backoff (3 attempts, 1s/2s/4s) for transient failures (429, 500, 502, 503, 504)
 - **Listing**: Query available reports by ticker, year, period
 - **Fetching**: Download reports with parallel workers
 - **Downloading**: Atomic file writes via safefile
+- **Registry**: ETag-based conditional fetching (`FetchRegistryConditional`) to skip re-downloading unchanged data
 
 ### Upgrade (`internal/upgrade/`)
 
@@ -165,5 +178,9 @@ Three-layer pipeline for extracting key-value pairs from corporate presentations
 - **Pure Go, no CGO**: Single static binary with no external dependencies at runtime
 - **Internal only**: All packages live under `internal/` -- no public API surface
 - **Interface-driven**: Cross-layer boundaries use interfaces for testability and decoupling
+- **Open-Closed Principle**: Extractor registry allows adding formats without modifying dispatch logic
+- **DRY flag helpers**: Shared flag registration/parsing eliminates duplication across commands
+- **Resilient networking**: Exponential backoff retry for transient API failures
+- **Conditional fetching**: ETag caching for registry avoids unnecessary downloads
 - **Atomic writes**: File operations use safefile to prevent partial writes
 - **Local caching**: Downloaded reports are cached in `IDXLENS_HOME` (default: `~/.idxlens`)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -10,11 +10,19 @@ idxlens [command]
 
 IDXLens is a CLI tool that fetches and extracts structured financial data from Indonesia Stock Exchange (IDX) reports. Supports XLSX, XBRL, and PDF formats.
 
+## Global Flags
+
+| Flag        | Default | Description                                      |
+|------------|---------|--------------------------------------------------|
+| `--verbose` | `false` | Enable verbose output (structured logging to stderr) |
+
 ## Environment
 
-| Variable       | Default       | Description                    |
-|---------------|---------------|--------------------------------|
-| `IDXLENS_HOME` | `~/.idxlens` | Local cache and session directory |
+| Variable              | Default       | Description                              |
+|----------------------|---------------|------------------------------------------|
+| `IDXLENS_HOME`        | `~/.idxlens` | Local cache and session directory        |
+| `IDXLENS_AUTH_TIMEOUT` | `30s`        | Authentication timeout (e.g. `60s`, `2m`) |
+| `NO_COLOR`            |               | Disable colored output when set          |
 
 ## Commands
 
@@ -26,7 +34,9 @@ Authenticate with the IDX portal via headless Chrome. Stores the session locally
 idxlens auth
 ```
 
-Chrome must be installed. The command launches a headless browser session, navigates to the IDX portal, and stores authentication cookies in `IDXLENS_HOME`.
+Chrome must be installed. The command launches a headless browser session, navigates to the IDX portal, and stores authentication cookies (with expiry timestamps) in `IDXLENS_HOME`. The timeout can be configured via `IDXLENS_AUTH_TIMEOUT` (default: `30s`).
+
+If cookies have expired, commands that require authentication will return a clear error message prompting you to re-authenticate.
 
 ---
 
@@ -88,21 +98,28 @@ idxlens fetch TICKER[,TICKER...]
 | `--period`    | `-p`  |         | Filter by period (`Q1`, `Q2`, `Q3`, `FY`)          |
 | `--file-type` |       |         | Filter by file type (`xlsx`, `xbrl`, `pdf`)        |
 | `--workers`   | `-w`  | `4`     | Number of concurrent download workers              |
+| `--dry-run`   |       | `false` | List files that would be downloaded without downloading |
 
 **Examples:**
 
 ```sh
 # Fetch all reports for BBCA
-idxlens fetch BBCA
+idxlens fetch BBCA -y 2025
 
 # Fetch specific year and period
 idxlens fetch BBCA -y 2024 -p Q3
+
+# Preview files without downloading
+idxlens fetch BBCA -y 2025 --dry-run
+
+# Preview with file type filter
+idxlens fetch BBCA -y 2025 --dry-run --file-type xlsx
 
 # Fetch only XLSX files with 8 workers
 idxlens fetch BBCA,BMRI -y 2024 --file-type xlsx -w 8
 ```
 
-Reports are saved to `IDXLENS_HOME/reports/<ticker>/`.
+Reports are saved to `IDXLENS_HOME/data/<ticker>/<year>/<period>/`.
 
 ---
 

--- a/docs/examples/basic-extraction.md
+++ b/docs/examples/basic-extraction.md
@@ -90,3 +90,27 @@ idxlens extract report.xlsx | jq '.items | length'
 ```sh
 idxlens analyze BBCA -y 2024 -p Q3 | jq '.items[] | {label: .label, value: .values["2024-09-30"]}'
 ```
+
+## Preview available files
+
+Use dry-run mode to see what files are available before downloading:
+
+```sh
+# List all available files
+idxlens fetch BBCA -y 2025 --dry-run
+
+# Filter by file type
+idxlens fetch BBCA -y 2025 --dry-run --file-type xlsx
+```
+
+## Verbose output
+
+Enable structured logging for debugging:
+
+```sh
+# See detailed fetch and extraction progress
+idxlens analyze BBCA -y 2024 -p Q3 --verbose
+
+# Verbose output goes to stderr, JSON to stdout -- pipe-friendly
+idxlens analyze BBCA -y 2024 --verbose 2>/dev/null | jq '.facts | length'
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,16 +88,22 @@ idxlens list BBCA -y 2024 -p Q3
 idxlens fetch BBCA -y 2024 -p Q3
 ```
 
-This downloads reports to the local cache at `~/.idxlens/reports/BBCA/`.
+This downloads reports to the local cache at `~/.idxlens/data/BBCA/2024/Q3/`.
+
+Preview files before downloading:
+
+```sh
+idxlens fetch BBCA -y 2024 --dry-run
+```
 
 ### 4. Extract financial data
 
 ```sh
 # From a local XLSX file
-idxlens extract ~/.idxlens/reports/BBCA/2024-Q3.xlsx --pretty
+idxlens extract ~/.idxlens/data/BBCA/2024/Q3/FinancialStatement-2024-III-BBCA.xlsx --pretty
 
 # From a XBRL ZIP archive
-idxlens extract ~/.idxlens/reports/BBCA/2024-Q3.zip
+idxlens extract ~/.idxlens/data/BBCA/2024/Q3/inlineXBRL.zip
 
 # Presentation KV extraction from PDF
 idxlens extract presentation.pdf --mode presentation
@@ -117,6 +123,12 @@ Analyze multiple tickers at once:
 
 ```sh
 idxlens analyze BBCA,BMRI,BBRI -y 2024 -p Q3
+```
+
+Enable verbose output for debugging:
+
+```sh
+idxlens analyze BBCA -y 2024 --verbose
 ```
 
 ### Keep IDXLens up to date


### PR DESCRIPTION
## Issue
N/A

## Summary
- Update CLAUDE.md with new architecture details (extractor registry, retry, service layer, flag helpers, env vars)
- Update README.md with new features (dry-run, verbose, retry, ETag caching, cookie expiry)
- Update docs/cli-reference.md with `--verbose` global flag, `--dry-run` fetch flag, new env vars
- Update docs/architecture.md with extractor registry pattern, service analyze pipeline, retry, design principles
- Update docs/getting-started.md with corrected cache paths and new features
- Update docs/examples/basic-extraction.md with dry-run and verbose examples

## Test Plan
- [x] Linter passes (`make lint`)
- [x] All tests pass (`make test`)
- [x] Documentation-only changes, no code modifications

## Notes
Prepares documentation for v1.1.3 release covering PRs #136-#146.
