### PR TITLE
refactor: extract shared helper package and deduplicate test boilerplate

### DIFF
--- a/internal/cli/analyze_test.go
+++ b/internal/cli/analyze_test.go
@@ -12,23 +12,7 @@ import (
 )
 
 func TestAnalyzeCommandRegistered(t *testing.T) {
-	found := false
-
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "analyze TICKER[,TICKER...]" {
-			found = true
-
-			if cmd.Short == "" {
-				t.Error("analyze command has empty Short description")
-			}
-
-			break
-		}
-	}
-
-	if !found {
-		t.Error("analyze command not registered on rootCmd")
-	}
+	assertCommandRegistered(t, "analyze TICKER[,TICKER...]")
 }
 
 func TestAnalyzeCommandFlags(t *testing.T) {

--- a/internal/cli/auth_test.go
+++ b/internal/cli/auth_test.go
@@ -18,21 +18,5 @@ func TestRunAuthFails(t *testing.T) {
 }
 
 func TestAuthCommandRegistered(t *testing.T) {
-	found := false
-
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "auth" {
-			found = true
-
-			if cmd.Short == "" {
-				t.Error("auth command has empty Short description")
-			}
-
-			break
-		}
-	}
-
-	if !found {
-		t.Error("auth command not registered on rootCmd")
-	}
+	assertCommandRegistered(t, "auth")
 }

--- a/internal/cli/command_test.go
+++ b/internal/cli/command_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import "testing"
+
+func assertCommandRegistered(t *testing.T, use string) {
+	t.Helper()
+
+	for _, cmd := range rootCmd.Commands() {
+		if cmd.Use == use {
+			if cmd.Short == "" {
+				t.Errorf("%s command has empty Short description", use)
+			}
+
+			return
+		}
+	}
+
+	t.Fatalf("%s command not registered on rootCmd", use)
+}

--- a/internal/cli/extract.go
+++ b/internal/cli/extract.go
@@ -2,11 +2,11 @@ package cli
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 
+	"github.com/lugassawan/idxlens/internal/helper"
 	"github.com/lugassawan/idxlens/internal/service"
 	"github.com/spf13/cobra"
 )
@@ -88,11 +88,7 @@ func writeJSON(w io.Writer, v any, pretty bool) error {
 }
 
 func marshalJSON(v any, pretty bool) ([]byte, error) {
-	if pretty {
-		return json.MarshalIndent(v, "", "  ")
-	}
-
-	return json.Marshal(v)
+	return helper.MarshalJSON(v, pretty)
 }
 
 func openWriter(cmd *cobra.Command, path string) (io.Writer, func(), error) {

--- a/internal/cli/extract.go
+++ b/internal/cli/extract.go
@@ -73,7 +73,7 @@ func writeResults(w io.Writer, results []any, pretty bool) error {
 }
 
 func writeJSON(w io.Writer, v any, pretty bool) error {
-	data, err := marshalJSON(v, pretty)
+	data, err := helper.MarshalJSON(v, pretty)
 	if err != nil {
 		return fmt.Errorf("marshal json: %w", err)
 	}
@@ -85,10 +85,6 @@ func writeJSON(w io.Writer, v any, pretty bool) error {
 	}
 
 	return nil
-}
-
-func marshalJSON(v any, pretty bool) ([]byte, error) {
-	return helper.MarshalJSON(v, pretty)
 }
 
 func openWriter(cmd *cobra.Command, path string) (io.Writer, func(), error) {

--- a/internal/cli/extract_test.go
+++ b/internal/cli/extract_test.go
@@ -352,31 +352,6 @@ func TestWriteJSONWriteError(t *testing.T) {
 	}
 }
 
-func TestMarshalJSON(t *testing.T) {
-	tests := []struct {
-		name   string
-		v      any
-		pretty bool
-		want   string
-	}{
-		{"compact", []int{1, 2}, false, "[1,2]"},
-		{"pretty", []int{1, 2}, true, "[\n  1,\n  2\n]"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := marshalJSON(tt.v, tt.pretty)
-			if err != nil {
-				t.Fatalf("marshalJSON() error: %v", err)
-			}
-
-			if string(got) != tt.want {
-				t.Errorf("marshalJSON() = %q, want %q", string(got), tt.want)
-			}
-		})
-	}
-}
-
 func TestOpenWriter(t *testing.T) {
 	t.Run("empty path returns stdout", func(t *testing.T) {
 		cmd := &cobra.Command{}

--- a/internal/cli/extract_test.go
+++ b/internal/cli/extract_test.go
@@ -20,18 +20,7 @@ func (errWriter) Write([]byte) (int, error) {
 }
 
 func TestExtractCommandRegistration(t *testing.T) {
-	found := false
-
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "extract [TICKER|FILE]" {
-			found = true
-			break
-		}
-	}
-
-	if !found {
-		t.Fatal("extract command not registered on root")
-	}
+	assertCommandRegistered(t, "extract [TICKER|FILE]")
 }
 
 func TestExtractCommandFlags(t *testing.T) {

--- a/internal/cli/fetch.go
+++ b/internal/cli/fetch.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +12,7 @@ import (
 	"sync"
 	"text/tabwriter"
 
+	"github.com/lugassawan/idxlens/internal/helper"
 	"github.com/lugassawan/idxlens/internal/idx"
 	"github.com/lugassawan/idxlens/internal/service"
 	"github.com/spf13/cobra"
@@ -73,7 +73,7 @@ func runFetch(cmd *cobra.Command, args []string) error {
 
 	logger.Info("fetch complete", "downloaded", len(summary.Downloaded), "failed", len(summary.Failed))
 
-	out, err := json.MarshalIndent(summary, "", "  ")
+	out, err := helper.MarshalJSONIndent(summary)
 	if err != nil {
 		return fmt.Errorf("marshal summary: %w", err)
 	}

--- a/internal/cli/fetch_test.go
+++ b/internal/cli/fetch_test.go
@@ -13,23 +13,7 @@ import (
 )
 
 func TestFetchCommandRegistered(t *testing.T) {
-	found := false
-
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "fetch TICKER[,TICKER...]" {
-			found = true
-
-			if cmd.Short == "" {
-				t.Error("fetch command has empty Short description")
-			}
-
-			break
-		}
-	}
-
-	if !found {
-		t.Error("fetch command not registered on rootCmd")
-	}
+	assertCommandRegistered(t, "fetch TICKER[,TICKER...]")
 }
 
 func TestFetchCommandFlags(t *testing.T) {

--- a/internal/cli/list_test.go
+++ b/internal/cli/list_test.go
@@ -13,23 +13,7 @@ import (
 )
 
 func TestListCommandRegistered(t *testing.T) {
-	found := false
-
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "list TICKER[,TICKER...]" {
-			found = true
-
-			if cmd.Short == "" {
-				t.Error("list command has empty Short description")
-			}
-
-			break
-		}
-	}
-
-	if !found {
-		t.Error("list command not registered on rootCmd")
-	}
+	assertCommandRegistered(t, "list TICKER[,TICKER...]")
 }
 
 func TestListCommandFlags(t *testing.T) {

--- a/internal/cli/upgrade_test.go
+++ b/internal/cli/upgrade_test.go
@@ -25,21 +25,5 @@ func TestIsDevBuild(t *testing.T) {
 }
 
 func TestUpgradeCommandRegistered(t *testing.T) {
-	found := false
-
-	for _, cmd := range rootCmd.Commands() {
-		if cmd.Use == "upgrade" {
-			found = true
-
-			if cmd.Short == "" {
-				t.Error("upgrade command has empty Short description")
-			}
-
-			break
-		}
-	}
-
-	if !found {
-		t.Error("upgrade command not registered on rootCmd")
-	}
+	assertCommandRegistered(t, "upgrade")
 }

--- a/internal/helper/json.go
+++ b/internal/helper/json.go
@@ -1,0 +1,19 @@
+package helper
+
+import "encoding/json"
+
+const jsonIndent = "  "
+
+// MarshalJSON serializes v to JSON. When pretty is true, output is indented.
+func MarshalJSON(v any, pretty bool) ([]byte, error) {
+	if pretty {
+		return json.MarshalIndent(v, "", jsonIndent)
+	}
+
+	return json.Marshal(v)
+}
+
+// MarshalJSONIndent serializes v to indented JSON.
+func MarshalJSONIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", jsonIndent)
+}

--- a/internal/helper/json_test.go
+++ b/internal/helper/json_test.go
@@ -1,0 +1,71 @@
+package helper
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMarshalJSON(t *testing.T) {
+	v := map[string]int{"a": 1}
+
+	tests := []struct {
+		name   string
+		pretty bool
+		want   string
+	}{
+		{"compact", false, `{"a":1}`},
+		{"pretty", true, "{\n  \"a\": 1\n}"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := MarshalJSON(v, tt.pretty)
+			if err != nil {
+				t.Fatalf("MarshalJSON() error: %v", err)
+			}
+
+			if string(got) != tt.want {
+				t.Errorf("MarshalJSON() = %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestMarshalJSONIndent(t *testing.T) {
+	v := map[string]int{"a": 1}
+	want := "{\n  \"a\": 1\n}"
+
+	got, err := MarshalJSONIndent(v)
+	if err != nil {
+		t.Fatalf("MarshalJSONIndent() error: %v", err)
+	}
+
+	if string(got) != want {
+		t.Errorf("MarshalJSONIndent() = %q, want %q", string(got), want)
+	}
+}
+
+func TestMarshalJSONError(t *testing.T) {
+	_, err := MarshalJSON(make(chan int), false)
+	if err == nil {
+		t.Fatal("expected error for unsupported type")
+	}
+}
+
+func TestMarshalJSONIndentMatchesStdlib(t *testing.T) {
+	v := []string{"hello", "world"}
+
+	got, err := MarshalJSONIndent(v)
+	if err != nil {
+		t.Fatalf("MarshalJSONIndent() error: %v", err)
+	}
+
+	want, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		t.Fatalf("json.MarshalIndent() error: %v", err)
+	}
+
+	if string(got) != string(want) {
+		t.Errorf("MarshalJSONIndent() = %q, want %q", string(got), string(want))
+	}
+}

--- a/internal/idx/auth.go
+++ b/internal/idx/auth.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/chromedp/cdproto/network"
 	"github.com/chromedp/chromedp"
+	"github.com/lugassawan/idxlens/internal/helper"
 )
 
 const (
@@ -74,7 +75,7 @@ func SaveCookies(path string, cookies []*http.Cookie) error {
 		}
 	}
 
-	data, err := json.MarshalIndent(entries, "", "  ")
+	data, err := helper.MarshalJSONIndent(entries)
 	if err != nil {
 		return fmt.Errorf("marshal cookies: %w", err)
 	}

--- a/internal/idx/registry.go
+++ b/internal/idx/registry.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/lugassawan/idxlens/internal/helper"
 )
 
 const (
@@ -125,7 +127,7 @@ func LoadCachedRegistry(path string) (map[string]CompanyRegistry, error) {
 
 // SaveCachedRegistry writes a presentation registry to a local JSON file.
 func SaveCachedRegistry(path string, reg map[string]CompanyRegistry) error {
-	data, err := json.MarshalIndent(reg, "", "  ")
+	data, err := helper.MarshalJSONIndent(reg)
 	if err != nil {
 		return fmt.Errorf("save cached registry: marshal: %w", err)
 	}


### PR DESCRIPTION
## Issue
N/A — codebase tidy-up from audit

## Summary
- Create `internal/helper` package with shared `MarshalJSON` / `MarshalJSONIndent` utilities, replacing 4 duplicated `json.MarshalIndent` calls across `cli/` and `idx/` packages
- Extract shared `assertCommandRegistered` test helper, replacing 6 identical ~15-line `Test*CommandRegistered` functions with 1-line calls
- Fix `extract_test.go` to validate `Short` description like all other command tests

## Test Plan
- [x] Linter passes (`make lint`) — 0 issues
- [x] All tests pass (`make test`) — 12 packages
- [x] `go vet ./...` clean
- [x] Dev build compiles (`make build`)

## Notes
- `writeJSON` / `writeResults` remain in `cli/extract.go` since they handle `io.Writer` semantics specific to CLI output
- `internal/helper` is designed as a general-purpose shared utility package for future cross-package helpers
